### PR TITLE
Add holidays and work item editing

### DIFF
--- a/templates/add_holiday.html
+++ b/templates/add_holiday.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Add Holiday</h2>
+<form method="post" class="mt-3">
+  <div class="mb-3">
+    <label class="form-label">Date
+      <input name="holiday_date" type="date" class="form-control" required>
+    </label>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,6 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_holidays') }}">Holidays</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_timeoff') }}">TimeOff</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('project_form') }}">New Project</a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('view_workitems') }}">WorkItems</a></li>
         </ul>
       </div>
     </div>

--- a/templates/edit_workitem.html
+++ b/templates/edit_workitem.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit WorkItem {{ item.WorkId }}</h2>
+<form method="post" class="mt-3">
+  <div class="mb-3">
+    <label class="form-label">Remaining Hours
+      <input name="remaining_hours" value="{{ item.RemainingHours }}" step="0.5" class="form-control" required>
+    </label>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/holidays.html
+++ b/templates/holidays.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Holidays</h2>
+<a class="btn btn-primary mb-3" href="{{ url_for('add_holiday') }}">Add Holiday</a>
 <ul class="list-group mt-3">
   {% for d in holidays %}
     <li class="list-group-item">{{ d }}</li>

--- a/templates/project_form.html
+++ b/templates/project_form.html
@@ -13,13 +13,13 @@
     </label>
   </div>
   <div class="mb-3">
-    <label class="form-label">Start
-      <input name="proj_start" type="datetime-local" class="form-control" required>
+    <label class="form-label">Start Date
+      <input name="proj_start" type="date" value="{{ today }}" class="form-control" required>
     </label>
   </div>
   <div class="mb-3">
-    <label class="form-label">End
-      <input name="proj_end" type="datetime-local" class="form-control" required>
+    <label class="form-label">Deadline Date
+      <input name="proj_end" type="date" value="{{ today }}" class="form-control" required>
     </label>
   </div>
   <button type="submit" class="btn btn-primary">Check Availability</button>

--- a/templates/workitems.html
+++ b/templates/workitems.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>WorkItems</h2>
 
 <form method="get" class="row g-2 mb-3">
   <div class="col-sm-4">
@@ -31,7 +30,7 @@
   <tr>
     <th>ID</th><th>Project</th><th>Est</th>
     <th>Start</th><th>End</th>
-    <th>Resource</th><th>Assigned At</th><th>Status</th>
+    <th>Resource</th><th>Assigned At</th><th>Remaining</th><th>Status</th><th></th>
   </tr>
   {% for w in workitems %}
   <tr>
@@ -42,7 +41,9 @@
     <td>{{ w.ProjEnd }}</td>
     <td>{{ w.ResourceName or w.AssignedResource }}</td>
     <td>{{ w.AssignDatetime }}</td>
+    <td>{{ w.RemainingHours }}</td>
     <td>{{ w.Status }}</td>
+    <td><a class="btn btn-sm btn-secondary" href="{{ url_for('edit_workitem', work_id=w.WorkId) }}">Edit</a></td>
   </tr>
   {% endfor %}
 </table>


### PR DESCRIPTION
## Summary
- allow adding holidays and editing work items
- compute project status using remaining hours
- use date pickers for project start and deadline dates
- remove WorkItems heading and link from navigation
- show remaining hours column and edit button

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6879bfca99dc83318bd5d4e5d5a9024f