### PR TITLE
Enhance work item management

### DIFF
--- a/templates/add_note.html
+++ b/templates/add_note.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Notes for WorkItem {{ item.WorkId }}</h2>
+<form method="post" class="mt-3">
+  <div class="mb-3">
+    <textarea name="notes" class="form-control" rows="4">{{ item.Notes }}</textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/edit_workitem.html
+++ b/templates/edit_workitem.html
@@ -7,6 +7,11 @@
       <input name="remaining_hours" value="{{ item.RemainingHours }}" step="0.5" class="form-control" required>
     </label>
   </div>
+  <div class="mb-3">
+    <label class="form-label">Notes
+      <textarea name="notes" class="form-control" rows="4">{{ item.Notes }}</textarea>
+    </label>
+  </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/workitems.html
+++ b/templates/workitems.html
@@ -30,7 +30,7 @@
   <tr>
     <th>ID</th><th>Project</th><th>Est</th>
     <th>Start</th><th>End</th>
-    <th>Resource</th><th>Assigned At</th><th>Remaining</th><th>Status</th><th></th>
+    <th>Resource</th><th>Assigned At</th><th>Remaining</th><th>Status</th><th>Action</th>
   </tr>
   {% for w in workitems %}
   <tr>
@@ -43,7 +43,13 @@
     <td>{{ w.AssignDatetime }}</td>
     <td>{{ w.RemainingHours }}</td>
     <td>{{ w.Status }}</td>
-    <td><a class="btn btn-sm btn-secondary" href="{{ url_for('edit_workitem', work_id=w.WorkId) }}">Edit</a></td>
+    <td class="d-flex gap-1">
+      <a class="btn btn-sm btn-secondary" href="{{ url_for('edit_workitem', work_id=w.WorkId) }}">Edit</a>
+      <a class="btn btn-sm btn-info" href="{{ url_for('add_note', work_id=w.WorkId) }}">Note</a>
+      <a class="btn btn-sm btn-warning" href="{{ url_for('pause_workitem', work_id=w.WorkId) }}">Pause</a>
+      <a class="btn btn-sm btn-success" href="{{ url_for('complete_workitem', work_id=w.WorkId) }}">Complete</a>
+      <a class="btn btn-sm btn-danger" href="{{ url_for('delete_workitem', work_id=w.WorkId) }}" onclick="return confirm('Delete this item?');">Delete</a>
+    </td>
   </tr>
   {% endfor %}
 </table>


### PR DESCRIPTION
## Summary
- allow notes column in WorkItem dataset
- let users edit notes and remaining hours
- add routes for notes, pause, completion and deletion
- show new actions on work item list

## Testing
- `python -m flask --app app.py routes`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6879d1a8b8a08331a7b1d831daa39ab0