### PR TITLE
Add note history and status filtering

### DIFF
--- a/templates/add_note.html
+++ b/templates/add_note.html
@@ -1,10 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Notes for WorkItem {{ item.WorkId }}</h2>
+
+{% if notes %}
+  <ul class="list-group mb-3">
+  {% for n in notes %}
+    <li class="list-group-item">{{ n }}</li>
+  {% endfor %}
+  </ul>
+{% endif %}
+
 <form method="post" class="mt-3">
   <div class="mb-3">
-    <textarea name="notes" class="form-control" rows="4">{{ item.Notes }}</textarea>
+    <textarea name="note_text" class="form-control" rows="3" placeholder="Add note..."></textarea>
   </div>
-  <button type="submit" class="btn btn-primary">Save</button>
+  <button type="submit" class="btn btn-primary">Add Note</button>
 </form>
 {% endblock %}

--- a/templates/workitems.html
+++ b/templates/workitems.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <form method="get" class="row g-2 mb-3">
-  <div class="col-sm-4">
+  <div class="col-sm-3">
     <input type="text" name="search" value="{{ search }}" placeholder="Search" class="form-control">
   </div>
   <div class="col-sm-3">
@@ -22,6 +22,14 @@
     </select>
   </div>
   <div class="col-sm-2">
+    <select name="status" class="form-select">
+      <option value="">All Status</option>
+      <option value="Active" {% if selected_status=='Active' %}selected{% endif %}>Active</option>
+      <option value="Paused" {% if selected_status=='Paused' %}selected{% endif %}>Paused</option>
+      <option value="Completed" {% if selected_status=='Completed' %}selected{% endif %}>Completed</option>
+    </select>
+  </div>
+  <div class="col-sm-1">
     <button type="submit" class="btn btn-primary w-100">Apply</button>
   </div>
 </form>


### PR DESCRIPTION
## Summary
- append timestamped notes for each work item
- show notes history on the note page
- filter work items by status (active/paused/completed)
- expose status filter in work items list

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d5744fd883319c4dd412da17a845