### PR TITLE
Add notes management page with icon buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -385,6 +385,34 @@ def add_note(work_id):
     return render_template('add_note.html', item=row)
 
 
+@app.route('/notes')
+def view_notes():
+    df = load_workitems()
+    df = df[df['Notes'].astype(str).str.strip() != '']
+    df_res = load_resources()[['ResourceId', 'ResourceName']]
+    df = df.merge(
+        df_res,
+        left_on='AssignedResource',
+        right_on='ResourceId',
+        how='left'
+    )
+    records = df.to_dict('records')
+    return render_template('notes.html', notes=records)
+
+
+@app.route('/delete_note/<int:work_id>')
+def delete_note(work_id):
+    df_wi = load_workitems()
+    if work_id in df_wi['WorkId'].values:
+        idx = df_wi.index[df_wi['WorkId'] == work_id][0]
+        df_wi.at[idx, 'Notes'] = ''
+        save_workitems(df_wi)
+        flash('Note deleted.', 'success')
+    else:
+        flash('WorkItem not found.', 'error')
+    return redirect(url_for('view_notes'))
+
+
 @app.route('/pause_workitem/<int:work_id>')
 def pause_workitem(work_id):
     df_wi = load_workitems()

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Resource Management</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
@@ -16,6 +17,7 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_holidays') }}">Holidays</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_timeoff') }}">TimeOff</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_workitems') }}">WorkItems</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('view_notes') }}">Notes</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('project_form') }}">New Project</a></li>
         </ul>
       </div>

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="mb-4">Notes</h2>
+<div class="table-responsive">
+<table class="table table-bordered table-striped table-hover">
+  <tr>
+    <th>ID</th>
+    <th>Project</th>
+    <th>Resource</th>
+    <th>Note</th>
+    <th>Action</th>
+  </tr>
+  {% for n in notes %}
+  <tr>
+    <td>{{ n.WorkId }}</td>
+    <td>{{ n.ProjectName }}</td>
+    <td>{{ n.ResourceName or n.AssignedResource }}</td>
+    <td>{{ n.Notes }}</td>
+    <td class="d-flex gap-1">
+      <a class="btn btn-sm btn-secondary" title="Edit" href="{{ url_for('add_note', work_id=n.WorkId) }}"><i class="bi bi-pencil"></i></a>
+      <a class="btn btn-sm btn-danger" title="Delete" href="{{ url_for('delete_note', work_id=n.WorkId) }}" onclick="return confirm('Delete this note?');"><i class="bi bi-trash"></i></a>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+</div>
+{% endblock %}

--- a/templates/workitems.html
+++ b/templates/workitems.html
@@ -45,11 +45,11 @@
     <td>{{ w.RemainingHours }}</td>
     <td>{{ w.Status }}</td>
     <td class="d-flex gap-1">
-      <a class="btn btn-sm btn-secondary" href="{{ url_for('edit_workitem', work_id=w.WorkId) }}">Edit</a>
-      <a class="btn btn-sm btn-info" href="{{ url_for('add_note', work_id=w.WorkId) }}">Note</a>
-      <a class="btn btn-sm btn-warning" href="{{ url_for('pause_workitem', work_id=w.WorkId) }}">Pause</a>
-      <a class="btn btn-sm btn-success" href="{{ url_for('complete_workitem', work_id=w.WorkId) }}">Complete</a>
-      <a class="btn btn-sm btn-danger" href="{{ url_for('delete_workitem', work_id=w.WorkId) }}" onclick="return confirm('Delete this item?');">Delete</a>
+      <a class="btn btn-sm btn-secondary" title="Edit" href="{{ url_for('edit_workitem', work_id=w.WorkId) }}"><i class="bi bi-pencil"></i></a>
+      <a class="btn btn-sm btn-info" title="Note" href="{{ url_for('add_note', work_id=w.WorkId) }}"><i class="bi bi-journal-text"></i></a>
+      <a class="btn btn-sm btn-warning" title="Pause" href="{{ url_for('pause_workitem', work_id=w.WorkId) }}"><i class="bi bi-pause"></i></a>
+      <a class="btn btn-sm btn-success" title="Complete" href="{{ url_for('complete_workitem', work_id=w.WorkId) }}"><i class="bi bi-check-circle"></i></a>
+      <a class="btn btn-sm btn-danger" title="Delete" href="{{ url_for('delete_workitem', work_id=w.WorkId) }}" onclick="return confirm('Delete this item?');"><i class="bi bi-trash"></i></a>
     </td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- include Bootstrap Icons
- add navigation link for Notes
- list existing notes in a new page with edit/delete icons
- display icon buttons on WorkItems list
- support viewing and deleting notes in `app.py`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ffb45aa2c8331bfbce399f0816f10