### PR TITLE
Add task manager screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This Flask-based app allows you to:
 - Manage Resources with daily work hour limits (WorkingHrs)
 - Record TimeOff days for each resource
 - Add Work Items with estimated hours and a preferred resource
+- Manage active tasks via the Task Manager screen
 - Automatically compute expected end date and task status (On Track, At Risk, Very Risky)
 - Store and retrieve data using Excel (`ResourceSheet.xlsx`)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,7 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_holidays') }}">Holidays</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_timeoff') }}">TimeOff</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_workitems') }}">WorkItems</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('task_manager') }}">Task Manager</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('view_notes') }}">Notes</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('project_form') }}">New Project</a></li>
         </ul>

--- a/templates/task_manager.html
+++ b/templates/task_manager.html
@@ -1,0 +1,58 @@
+{% extends 'base.html' %}
+{% block content %}
+
+<h2 class="mb-4">Task Manager</h2>
+<form method="get" class="row gy-2 gx-3 align-items-end mb-4">
+  <div class="col-sm-4">
+    <input type="text" name="search" value="{{ search }}" placeholder="Search" class="form-control">
+  </div>
+  <div class="col-sm-3">
+    <select name="resource" class="form-select">
+      <option value="">All Resources</option>
+      {% for r in resources %}
+        <option value="{{ r.ResourceId }}" {% if r.ResourceId == selected_resource %}selected{% endif %}>{{ r.ResourceName }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-sm-3">
+    <select name="sort" class="form-select">
+      <option value="">Sort By</option>
+      <option value="start" {% if sort=='start' %}selected{% endif %}>Start</option>
+      <option value="end" {% if sort=='end' %}selected{% endif %}>End</option>
+      <option value="resource" {% if sort=='resource' %}selected{% endif %}>Resource</option>
+    </select>
+  </div>
+  <div class="col-sm-2">
+    <button type="submit" class="btn btn-primary w-100">Apply</button>
+  </div>
+</form>
+<div class="table-responsive">
+<table class="table table-bordered table-striped table-hover">
+  <tr>
+    <th>ID</th><th>Project</th><th>Est</th>
+    <th>Start</th><th>End</th>
+    <th>Resource</th><th>Assigned At</th><th>Remaining</th><th>Status</th><th>Action</th>
+  </tr>
+  {% for w in workitems %}
+  <tr>
+    <td>{{ w.WorkId }}</td>
+    <td>{{ w.ProjectName }}</td>
+    <td>{{ w.Estimate }}</td>
+    <td>{{ w.ProjStart }}</td>
+    <td>{{ w.ProjEnd }}</td>
+    <td>{{ w.ResourceName or w.AssignedResource }}</td>
+    <td>{{ w.AssignDatetime }}</td>
+    <td>{{ w.RemainingHours }}</td>
+    <td>{{ w.Status }}</td>
+    <td class="d-flex gap-1">
+      <a class="btn btn-sm btn-secondary" title="Edit" href="{{ url_for('edit_workitem', work_id=w.WorkId) }}"><i class="bi bi-pencil"></i></a>
+      <a class="btn btn-sm btn-info" title="Note" href="{{ url_for('add_note', work_id=w.WorkId) }}"><i class="bi bi-journal-text"></i></a>
+      <a class="btn btn-sm btn-warning" title="Pause" href="{{ url_for('pause_workitem', work_id=w.WorkId) }}"><i class="bi bi-pause"></i></a>
+      <a class="btn btn-sm btn-success" title="Complete" href="{{ url_for('complete_workitem', work_id=w.WorkId) }}"><i class="bi bi-check-circle"></i></a>
+      <a class="btn btn-sm btn-danger" title="Delete" href="{{ url_for('delete_workitem', work_id=w.WorkId) }}" onclick="return confirm('Delete this item?');"><i class="bi bi-trash"></i></a>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `/task_manager` route to manage active tasks
- replicate work item view as `task_manager.html`
- link Task Manager from the navigation bar
- document Task Manager screen in README

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py` *(fails initially: ModuleNotFoundError: No module named 'flask')*
- `pip install --force-reinstall pandas==2.2.2 numpy==1.26.4`
- `python app.py` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6880066a7b9c83318f6ed9e409540747